### PR TITLE
fix(index.js): proper string type check

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
   },
 
   getTestAppPath() {
-    return typeof this.app.options.configPath === String ? './tests/dummy' : '';
+    let configPath = this.app.options.configPath;
+    return (typeof configPath === 'string' || configPath instanceof String) ? './tests/dummy' : '';
   }
 };


### PR DESCRIPTION
this previously failed to build the dev `dummy/app/tests` tree in certain build environments due to the string type check failing

**EDIT**: Not sure why Travis is complaining, try to restart the job?