### PR TITLE
feat(markdown-menu): add optional `fragmentIdLinks` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ order: 0
 Lorem ipsum dolor sit amet...
 ```
 
+Additionally, adding a `fragmentIdLinks` object to a file's frontmatter will generate a list local fragment identifier links which are used within the `{{markdown-menu-item}}` component. This is handy when you want to link to several individual sections of a large parent markdown file instead of having individual child markdown files.
+
+The `fragmentIdLinks` object expects child key-value pairs where each `key` represents the hash fragment id link and each `value` represents the text label to be shown as a child on the `{{markdown-menu}}` component.
+
+```md
+---
+title: Fragment Identifier Links
+order: 4
+fragmentIdLinks:
+  iamsectionone: "Section One"
+  section-two: "Section Two"
+---
+
+### I am section one
+Lorem ipsum dolor sit amet...
+
+<a id="section-two">Lorem ipsum dolor sit amet...
+```
+
 The addon ships with a `markdown-menu` component which builds a nested list from your file tree and can be styled using your own css.
 
 ```hbs

--- a/README.md
+++ b/README.md
@@ -116,11 +116,34 @@ fragmentIdLinks:
   iamsectionone: "Section One"
   section-two: "Section Two"
 ---
+```
 
 ### I am section one
 Lorem ipsum dolor sit amet...
 
 <a id="section-two">Lorem ipsum dolor sit amet...
+```
+
+By default, when you click on each `fragmentIdLinks` child link within the `{{markdown-menu-item}}` component it will update the url hash. You can easily override this default behavior by passing an `onClick` closure action into the `{{markdown-menu}}` component.
+
+```hbs 
+{{!-- templates/guides.hbs --}}
+{{markdown-menu onClick=(action "clickedMenuItemLink")}}
+```
+
+```js 
+// controllers/guides.js
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    clickedMenuItemLink(fragmentIdLink) {
+      document.querySelector(`#${fragmentIdLink}`).scrollIntoView({
+        behavior: 'smooth'
+      });
+    }
+  }
+});
 ```
 
 The addon ships with a `markdown-menu` component which builds a nested list from your file tree and can be styled using your own css.

--- a/addon/components/markdown-menu-item.js
+++ b/addon/components/markdown-menu-item.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import { empty } from '@ember/object/computed';
-import { scheduleOnce } from '@ember/runloop';
 
 import layout from 'ember-cli-markdown-resolver/templates/components/markdown-menu-item';
 
@@ -20,12 +19,12 @@ export default Component.extend({
   noContent: empty('item.content'),
 
   actions: {
-    navigateToHash(fragmentIdLink = '') {
-      scheduleOnce('afterRender', this, '_navigateToHash', fragmentIdLink);
-    }
-  },
+    onClick(fragmentIdLink) {
+      let onClick = get(this, 'onClick');
 
-  _navigateToHash(fragmentIdLink) {
-    location.hash = fragmentIdLink;
+      if (onClick) {
+        onClick(fragmentIdLink);
+      }
+    }
   }
 });

--- a/addon/components/markdown-menu-item.js
+++ b/addon/components/markdown-menu-item.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import { empty } from '@ember/object/computed';
+import { scheduleOnce } from '@ember/runloop';
 
 import layout from 'ember-cli-markdown-resolver/templates/components/markdown-menu-item';
 
@@ -16,6 +17,15 @@ export default Component.extend({
     return itemPath.replace(`${treePath}/`, '');
   }),
 
-  noContent: empty('item.content')
+  noContent: empty('item.content'),
 
+  actions: {
+    navigateToHash(fragmentIdLink = '') {
+      scheduleOnce('afterRender', this, '_navigateToHash', fragmentIdLink);
+    }
+  },
+
+  _navigateToHash(fragmentIdLink) {
+    location.hash = fragmentIdLink;
+  }
 });

--- a/addon/components/markdown-menu.js
+++ b/addon/components/markdown-menu.js
@@ -1,7 +1,21 @@
 import Component from '@ember/component';
+import { scheduleOnce } from '@ember/runloop';
+import fallbackAction from 'ember-cli-markdown-resolver/utils/computed-fallback-action';
+
 import layout from 'ember-cli-markdown-resolver/templates/components/markdown-menu';
 
 export default Component.extend({
   layout,
-  classNames: ['markdown-menu']
+  classNames: ['markdown-menu'],
+
+  // Actions
+  onClick: fallbackAction(function(fragmentIdLink) {
+    if (fragmentIdLink && typeof fragmentIdLink === "string" && fragmentIdLink.length) {
+      scheduleOnce('afterRender', this, () => {
+        location.hash = fragmentIdLink;
+      });
+    } else {
+      location.hash = "";
+    }
+  })
 });

--- a/addon/templates/components/markdown-menu-item.hbs
+++ b/addon/templates/components/markdown-menu-item.hbs
@@ -1,9 +1,5 @@
 {{#unless noContent}}
-  {{#if item.attributes.fragmentIdLinks}}
-    {{link-to item.attributes.title linkTo itemPath click=(action "navigateToHash" "")}}
-  {{else}}
-    {{link-to item.attributes.title linkTo itemPath}}
-  {{/if}}
+  {{link-to item.attributes.title linkTo itemPath click=(action "onClick")}}
 {{else}}
   <a tabindex="0">{{item.attributes.title}}</a>
 {{/unless}}
@@ -12,7 +8,7 @@
   <ul>
     {{#each-in item.attributes.fragmentIdLinks as | fragmentIdLink label |}}
       <li>
-        {{link-to label linkTo itemPath click=(action "navigateToHash" fragmentIdLink) activeClass=""}}
+        {{link-to label linkTo itemPath click=(action "onClick" fragmentIdLink) activeClass=""}}
       </li>
     {{/each-in}}
   </ul>

--- a/addon/templates/components/markdown-menu-item.hbs
+++ b/addon/templates/components/markdown-menu-item.hbs
@@ -1,8 +1,22 @@
 {{#unless noContent}}
-  {{link-to item.attributes.title linkTo itemPath}}
+  {{#if item.attributes.fragmentIdLinks}}
+    {{link-to item.attributes.title linkTo itemPath click=(action "navigateToHash" "")}}
+  {{else}}
+    {{link-to item.attributes.title linkTo itemPath}}
+  {{/if}}
 {{else}}
   <a tabindex="0">{{item.attributes.title}}</a>
 {{/unless}}
+
+{{#if item.attributes.fragmentIdLinks}}
+  <ul>
+    {{#each-in item.attributes.fragmentIdLinks as | fragmentIdLink label |}}
+      <li>
+        {{link-to label linkTo itemPath click=(action "navigateToHash" fragmentIdLink) activeClass=""}}
+      </li>
+    {{/each-in}}
+  </ul>
+{{/if}}
 
 {{#if item.children}}
   <ul>

--- a/addon/templates/components/markdown-menu.hbs
+++ b/addon/templates/components/markdown-menu.hbs
@@ -4,7 +4,7 @@
   </div>
   <ul>
     {{#each tree.files as | item |}}
-      {{markdown-menu-item item=item treePath=tree.path linkTo=linkTo}}
+      {{markdown-menu-item item=item treePath=tree.path linkTo=linkTo onClick=(action onClick)}}
     {{/each}}
   </ul>
 {{/if}}

--- a/addon/utils/computed-fallback-action.js
+++ b/addon/utils/computed-fallback-action.js
@@ -1,0 +1,12 @@
+import { computed } from '@ember/object';
+
+export default function computedFallbackAction(fallback) {
+  return computed({
+    get() {
+      return fallback.bind(this);
+    },
+    set(_, v) {
+      return v === undefined ? fallback.bind(this) : v;
+    }
+  });
+}

--- a/tests/dummy/app/guides/fragment-identifiers.md
+++ b/tests/dummy/app/guides/fragment-identifiers.md
@@ -1,0 +1,34 @@
+---
+title: Fragment Identifier Links
+order: 4
+fragmentIdLinks:
+  iamsectionone: "Section One"
+  section-two: "Section Two"
+---
+
+* [Section One Link](#iamsectionone)
+* [Section Two Link](#section-two)
+
+### I am Section One
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum aliquam dictum quam. Donec lobortis purus ut sagittis laoreet. Sed nisl metus, vulputate ut nunc a, pretium sodales lorem. Phasellus ultricies ipsum et sapien auctor, eget auctor lacus luctus. Suspendisse vitae ligula at leo sagittis rhoncus. Nulla porta auctor ex eu dictum. Morbi ut ante sit amet dui tincidunt commodo eu id mauris. Integer eu cursus tortor. Morbi vehicula ultrices fringilla. Fusce vitae ante sit amet turpis cursus cursus. Vivamus sagittis rutrum gravida. Donec finibus arcu eu quam consequat convallis vitae non odio. Cras lorem sapien, vestibulum nec ornare eu, rutrum id quam. Maecenas at arcu consectetur, suscipit lectus sit amet, porta turpis. Suspendisse tortor turpis, cursus vel diam id, accumsan convallis odio.
+
+Curabitur tristique tellus vel metus dictum, vel vehicula elit aliquet. Ut iaculis est in tellus varius lacinia. Nam consectetur venenatis molestie. Aliquam euismod massa pulvinar arcu finibus, in rutrum nunc bibendum. Cras at porttitor nisl, et finibus justo. Fusce volutpat elementum consectetur. Mauris ut massa ac magna mollis malesuada. Vivamus non egestas justo. Pellentesque convallis, lacus sit amet pulvinar dapibus, dui lorem condimentum eros, in tempus nulla nibh eu magna. Phasellus et eros id libero suscipit condimentum. Pellentesque tristique risus et bibendum volutpat. Nullam eget maximus ex. Aliquam lobortis, augue vel viverra pharetra, leo nisi mollis libero, id tincidunt nisl augue vel ligula.
+
+Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eget sodales neque. Etiam a lectus tempor, euismod elit id, porta ipsum. Suspendisse luctus, lacus sit amet finibus ultrices, nisi eros ornare ex, eu sollicitudin nisi elit sit amet est. Nulla quis dignissim nisi. Proin sit amet eleifend ligula. Nunc nec tristique elit. Donec facilisis efficitur condimentum.
+
+Sed maximus quam et nulla consectetur interdum. Fusce lobortis quis odio eget egestas. Vestibulum diam est, tincidunt non maximus at, mattis nec tellus. Quisque egestas finibus massa et sagittis. Morbi quis dui ut enim pharetra fermentum. Ut a venenatis quam. Curabitur suscipit mi at est mattis convallis. Nullam vel pellentesque ligula. Praesent id sapien vitae nulla rhoncus aliquam. Aenean vitae lobortis dolor, sit amet feugiat nulla. Nulla cursus a mi at dictum. Nulla eu ipsum consectetur, ornare lorem ac, varius massa. Fusce tincidunt risus nec consectetur bibendum. Etiam lorem turpis, mollis ac est id, tristique aliquam lorem. Sed vestibulum ante ut nisi condimentum consectetur.
+
+Ut fermentum eros bibendum scelerisque aliquam. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed laoreet laoreet nisl vitae maximus. Curabitur feugiat, enim et pretium suscipit, lectus mauris sollicitudin quam, et pretium lacus lorem et mi. Vivamus sapien enim, iaculis non finibus a, rutrum ut quam. Aliquam pellentesque elit a dignissim fringilla. Fusce volutpat pellentesque porttitor. Phasellus facilisis efficitur nibh, ut venenatis neque congue in. Aliquam eget cursus ligula.
+
+### I am Section Two
+
+<a id="section-two"></a> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum aliquam dictum quam. Donec lobortis purus ut sagittis laoreet. Sed nisl metus, vulputate ut nunc a, pretium sodales lorem. Phasellus ultricies ipsum et sapien auctor, eget auctor lacus luctus. Suspendisse vitae ligula at leo sagittis rhoncus. Nulla porta auctor ex eu dictum. Morbi ut ante sit amet dui tincidunt commodo eu id mauris. Integer eu cursus tortor. Morbi vehicula ultrices fringilla. Fusce vitae ante sit amet turpis cursus cursus. Vivamus sagittis rutrum gravida. Donec finibus arcu eu quam consequat convallis vitae non odio. Cras lorem sapien, vestibulum nec ornare eu, rutrum id quam. Maecenas at arcu consectetur, suscipit lectus sit amet, porta turpis. Suspendisse tortor turpis, cursus vel diam id, accumsan convallis odio.
+
+Curabitur tristique tellus vel metus dictum, vel vehicula elit aliquet. Ut iaculis est in tellus varius lacinia. Nam consectetur venenatis molestie. Aliquam euismod massa pulvinar arcu finibus, in rutrum nunc bibendum. Cras at porttitor nisl, et finibus justo. Fusce volutpat elementum consectetur. Mauris ut massa ac magna mollis malesuada. Vivamus non egestas justo. Pellentesque convallis, lacus sit amet pulvinar dapibus, dui lorem condimentum eros, in tempus nulla nibh eu magna. Phasellus et eros id libero suscipit condimentum. Pellentesque tristique risus et bibendum volutpat. Nullam eget maximus ex. Aliquam lobortis, augue vel viverra pharetra, leo nisi mollis libero, id tincidunt nisl augue vel ligula.
+
+Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eget sodales neque. Etiam a lectus tempor, euismod elit id, porta ipsum. Suspendisse luctus, lacus sit amet finibus ultrices, nisi eros ornare ex, eu sollicitudin nisi elit sit amet est. Nulla quis dignissim nisi. Proin sit amet eleifend ligula. Nunc nec tristique elit. Donec facilisis efficitur condimentum.
+
+Sed maximus quam et nulla consectetur interdum. Fusce lobortis quis odio eget egestas. Vestibulum diam est, tincidunt non maximus at, mattis nec tellus. Quisque egestas finibus massa et sagittis. Morbi quis dui ut enim pharetra fermentum. Ut a venenatis quam. Curabitur suscipit mi at est mattis convallis. Nullam vel pellentesque ligula. Praesent id sapien vitae nulla rhoncus aliquam. Aenean vitae lobortis dolor, sit amet feugiat nulla. Nulla cursus a mi at dictum. Nulla eu ipsum consectetur, ornare lorem ac, varius massa. Fusce tincidunt risus nec consectetur bibendum. Etiam lorem turpis, mollis ac est id, tristique aliquam lorem. Sed vestibulum ante ut nisi condimentum consectetur.
+
+Ut fermentum eros bibendum scelerisque aliquam. Interdum et malesuada fames ac ante ipsum primis in faucibus. Sed laoreet laoreet nisl vitae maximus. Curabitur feugiat, enim et pretium suscipit, lectus mauris sollicitudin quam, et pretium lacus lorem et mi. Vivamus sapien enim, iaculis non finibus a, rutrum ut quam. Aliquam pellentesque elit a dignissim fringilla. Fusce volutpat pellentesque porttitor. Phasellus facilisis efficitur nibh, ut venenatis neque congue in. Aliquam eget cursus ligula.


### PR DESCRIPTION
Quick updates after closing https://github.com/willviles/ember-cli-markdown-resolver/pull/7

By default the click handler will update the `window.location.hash`. Additionally, It also allows the user to pass in an `onClick` action handler as well so they can do something like this if they want to smooth-scroll.

```hbs 
{{! guides.hbs }}
{{markdown-menu tree=tree onClick=(action "onClick")}}
```

```js 
// controllers/guides.js
import Controller from '@ember/controller';
export default Controller.extend({
  actions: {
    onClick(fragmentIdLink) {
      document.querySelector(`#${fragmentIdLink}`).scrollIntoView({
        behavior: 'smooth'
      });
    }
  }
});
```

Let me know what you think of the solution or if you can think of something more elegant 🤷‍♂️. 

Unfortunately Ember doesn't solve this problem in a clean and easy way right now with `{{link-to}}`'s and hash fragment Id's.

Thanks for this addon, it's great!

---

Closes #6 