### PR TITLE
fix(service): fix bug when including multiple !`inTree` files without…

### DIFF
--- a/addon/services/markdown-resolver.js
+++ b/addon/services/markdown-resolver.js
@@ -72,17 +72,21 @@ export default Service.extend({
   },
 
   orderFiles(files) {
-    files = A(files).sortBy('attributes.order');
-    files.forEach(file => {
-      let inTree = get(file, 'attributes.inTree');
-      if (inTree === false) {
-        return files.removeObject(file);
+    files = A(files).sortBy('attributes.order').filter((file) => {
+      let attrs = get(file, 'attributes');
+      if (attrs.hasOwnProperty('inTree') && !get(attrs, 'inTree')) {
+        return;
       }
+      return file;
+    });
+
+    files.forEach(file => {
       let children = get(file, 'children');
       if (children) {
         set(file, 'children', this.orderFiles(children));
       }
     });
+
     return files;
   }
 

--- a/tests/dummy/app/guides/install.md
+++ b/tests/dummy/app/guides/install.md
@@ -1,6 +1,7 @@
 ---
 title: Installation
 order: 0
+inTree: true
 ---
 
 ```

--- a/tests/dummy/app/guides/not-in-tree.md
+++ b/tests/dummy/app/guides/not-in-tree.md
@@ -1,0 +1,6 @@
+---
+title: Not In Tree
+inTree: false
+---
+
+This file is not included in the results of `this.get('markdownResolver').tree(type)`


### PR DESCRIPTION
… a specified `order` front-matter prop

This solution to #9 is to break out the `inTree` check outside of the original `children` loop check into its own `filter` operation

---

Closes #9